### PR TITLE
flake: set pname/src for craneLib builds and add cargoAudit check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,10 @@
         checks = {
           build-tests = craneLib.buildPackage { inherit pname version cargoArtifacts src; };
 
+          audit = craneLib.cargoAudit {
+            inherit pname version src advisory-db;
+          };
+
           # Run clippy (and deny all warnings) on the crate source,
           # again, resuing the dependency artifacts from above.
           #


### PR DESCRIPTION
Setting pname/version should speed up evaluating the outputs, shouldn't rely on IFD to find the name/version.

Also added missing cargoAudit check (seems like it was intended because there's an otherwise unused advisory-db input).

Note: the formatting in flake.nix doesn't follow a formatter that I know of, tried alejandra and nixpkgs-fmt and both rewrite the entire thing.